### PR TITLE
exposed port 8880 for the UniFi guest login ui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,6 @@ RUN \
 ADD ./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 VOLUME /usr/lib/unifi/data
-EXPOSE  8443 8080 27117
+EXPOSE  8443 8880 8080 27117
 WORKDIR /usr/lib/unifi
 CMD ["/usr/bin/supervisord"]

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ release: test tag_latest
 rm:
 	docker stop $(NAME) || echo "container not running yet" && docker rm $(NAME) || echo "no container count yet"
 
-# 0.0.0:8080->8080/tcp, 0.0.0.0:8443->8443/tcp, 0.0.0.0:2222->22/tcp, 0.0.0.0:37117->27117/tcp
+# 0.0.0:8080->8080/tcp, 0.0.0.0:8443->8443/tcp, 0.0.0.0:8880->8880/tcp, 0.0.0.0:2222->22/tcp, 0.0.0.0:37117->27117/tcp
 run: rm 
 	docker run -d \
-                        -p 8443:8443 -p 37117:27117 -p 8080:8080 \
+                        -p 8443:8443 -p 37117:27117 -p 8080:8080 -p 8880:8880 \
                         -v /srv/data/apps/docker/unifi/data:/usr/lib/unifi/data \
                         --name=$(NAME) \
 			$(REPO):latest

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ make
 
 ```
     docker run -d \
-            -p 8080:8080 -p 8443:8443 -p 37117:27117 \
+            -p 8080:8080 -p 8443:8443 -p 8880:8880 -p 37117:27117 \
             -v /srv/data/apps/docker/unifi/data:/usr/lib/unifi/data \
             --name unifi rednut/unifi-controller
 ```
@@ -80,6 +80,7 @@ To connunicate with the unifi controller you mapo various ports, eg:
 
 - 8080: non tls web ui
 - 8443: tls web ui
+- 8880: guest login ui
 - 27117: mongo 
 
 ### command to run the unifi controller daemon
@@ -88,7 +89,7 @@ To launch a container using the image created earlier:
 
 ``` 
 	docker run -d \
-			-p 8080:8080 -p 8443:8443 -p 37117:27117 \
+			-p 8080:8080 -p 8443:8443 -p 8880:8880 -p 37117:27117 \
 			-v /srv/data/apps/docker/unifi/data:/usr/lib/unifi/data \
 			--name unifi rednut/unifi-controller
 ```

--- a/run-controller.sh
+++ b/run-controller.sh
@@ -12,6 +12,6 @@ docker rm -f $CONTAINER_NAME || echo "not a container yet: '$CONTAINER_NAME'"
 
 
 docker run -d \
-	-p 2222:22 -p 8080:8080 -p 8443:8443 -p 37117:27117 \
+	-p 2222:22 -p 8880:8880 -p 8080:8080 -p 8443:8443 -p 37117:27117 \
                         -v /srv/data/apps/docker/unifi/data:/usr/lib/unifi/data \
                         --name unifi rednut/unifi-controller


### PR DESCRIPTION
When the "Simple Password" guest control setting is enabled in the UniFi control panel, it spins up an application on port 8880 to direct guest traffic to for authentication.   Without port 8880 being exposed, the "Simple Password" guest control setting is unusable.  
