### PR TITLE
Update to unifi5 repo

### DIFF
--- a/100-ubnt.list
+++ b/100-ubnt.list
@@ -1,7 +1,7 @@
 ## Debian/Ubuntu
-# stable => unifi4
-# deb http://www.ubnt.com/downloads/unifi/debian unifi4 ubiquiti
-deb http://www.ubnt.com/downloads/unifi/debian stable ubiquiti
+# stable => unifi5
+deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti
+# deb http://www.ubnt.com/downloads/unifi/debian stable ubiquiti
 
 # optional mongo upstream repo
 ## Ubuntu


### PR DESCRIPTION
Is it prudent at this point to move to version 5 of the controller, or would you rather support it in a branch of your repo? At present, I'm using my own GitHub repo with the branch specified in the build context: 'https://github.com/overhacked/docker-unifi-controller.git#unifi5'
